### PR TITLE
fix border and divider visibility

### DIFF
--- a/ticketview/src/main/java/com/vipulasri/ticketview/TicketView.java
+++ b/ticketview/src/main/java/com/vipulasri/ticketview/TicketView.java
@@ -115,17 +115,18 @@ public class TicketView extends View {
         }
         canvas.drawPath(mPath, mBackgroundPaint);
         canvas.clipPath(mPath);
-        if (mShowBorder) {
-            canvas.drawPath(mPath, mBorderPaint);
-        }
-        if (mShowDivider) {
-            canvas.drawLine(mDividerStartX, mDividerStartY, mDividerStopX, mDividerStopY, mDividerPaint);
-        }
+
         if (mBackgroundAfterDivider != null) {
             setTicketBackgroundAfterDivider(canvas);
         }
         if (mBackgroundBeforeDivider != null) {
             setTicketBackgroundBeforeDivider(canvas);
+        }
+        if (mShowBorder) {
+            canvas.drawPath(mPath, mBorderPaint);
+        }
+        if (mShowDivider) {
+            canvas.drawLine(mDividerStartX, mDividerStartY, mDividerStopX, mDividerStopY, mDividerPaint);
         }
     }
 


### PR DESCRIPTION
if you set ticketBackgroundBeforeDivider and ticketBackgroundAfterDivider then border and divider don't visible.
Border and divider stays behind. First you draw border and divider, then you draw background.